### PR TITLE
Fix getOtherKey change

### DIFF
--- a/src/Relations/Joiner.php
+++ b/src/Relations/Joiner.php
@@ -189,7 +189,7 @@ class Joiner implements JoinerContract
         }
 
         if ($relation instanceof BelongsToMany) {
-            return [$relation->getOtherKey(), $relation->getRelated()->getQualifiedKeyName()];
+            return [$relation->getQualifiedRelatedKeyName(), $relation->getRelated()->getQualifiedKeyName()];
         }
 
         if ($relation instanceof HasManyThrough) {


### PR DESCRIPTION
It appears `getOtherKey` as dropped in 5.4. This PR changes the method to the new equivalent one.

